### PR TITLE
Adding percentile and median scaling

### DIFF
--- a/fits2image/conversions.py
+++ b/fits2image/conversions.py
@@ -28,7 +28,7 @@ def _add_label(image, label_text, label_font):
 
 
 def fits_to_jpg(path_to_fits, path_to_jpg, width=200, height=200, progressive=False, label_text='', label_font='DejaVuSansMono.ttf',
-                zmin=None, zmax=None, gamma_adjust=2.5, contrast=0.1, quality=95, color=False):
+                zmin=None, zmax=None, gamma_adjust=2.5, contrast=0.1, quality=95, color=False, percentile=99.5, median=False):
     '''Create a jpg from a fits file
         :param path_to_fits a single file or list (if color=True)
     '''
@@ -41,7 +41,7 @@ def fits_to_jpg(path_to_fits, path_to_jpg, width=200, height=200, progressive=Fa
             logging.error('Path {} does not exist'.format(path))
             return False
         scaled_images.append(
-            get_scaled_image(path, zmin=zmin, zmax=zmax, contrast=contrast, gamma_adjust=gamma_adjust, flip_v=True)
+            get_scaled_image(path, zmin=zmin, zmax=zmax, contrast=contrast, gamma_adjust=gamma_adjust, flip_v=True, percentile=percentile, median=median)
         )
 
     if color:

--- a/fits2image/scaling.py
+++ b/fits2image/scaling.py
@@ -6,7 +6,7 @@ import numpy as np
 from PIL import Image
 
 
-def get_scaled_image(path_to_fits, zmin=None, zmax=None, contrast=0.1, gamma_adjust=2.5, flip_v=True):
+def get_scaled_image(path_to_fits, zmin=None, zmax=None, contrast=0.1, gamma_adjust=2.5, flip_v=True, percentile=99.5, median=False):
     ''' Helper function to get a scaled PIL Image given a fits or compressed fits file path and scale parameters
     :param path_to_fits:
     :param zmin:
@@ -21,6 +21,8 @@ def get_scaled_image(path_to_fits, zmin=None, zmax=None, contrast=0.1, gamma_adj
         scaled_data = linear_scale(data, zmin, zmax, gamma_adjust=gamma_adjust)
     else:
         scaled_data = auto_scale(path_to_fits, contrast=contrast, gamma_adjust=gamma_adjust)
+    if median:
+        scaled_data = recalculate_median(scaled_data,percentile)
     im = Image.fromarray(scaled_data)
     if flip_v:
         im = im.transpose(Image.FLIP_TOP_BOTTOM)
@@ -208,3 +210,15 @@ def percentile_scale(path_to_frame, lower_percentile=5.0, upper_percentile=99.0)
     data[data > 255] = 255
     data = data.astype('uint8')
     return data
+
+def recalculate_median(data, percentile=99.5):
+    data = data.astype('float')
+    data[data < 0.] = 0.
+    median = np.median(data)
+    data -= median
+    data[data < 0.] = 0.
+    max_val = np.percentile(data, percentile)
+    scaled = data*255./(max_val)
+    scaled[scaled > 255.] = 255.
+    scaled = scaled.astype('uint8')
+    return scaled

--- a/fits2image/scaling.py
+++ b/fits2image/scaling.py
@@ -111,7 +111,7 @@ def extract_samples(data, header, nsamples=2000):
     flat_data = data.flatten()
 
     sample_stride = (header.get('NAXIS1') * header.get('NAXIS2')) / nsamples
-    samples = flat_data[sample_stride::sample_stride]
+    samples = flat_data[int(sample_stride)::int(sample_stride)]
     samples.sort()
 
     return samples


### PR DESCRIPTION
This was requested by Tim Lister. The current thumbnails don't have enough contrast to see faint asteroids. There is barely any difference in the speed of thumbnail generation compared to without the median filter. It is not enabled by default.