### PR TITLE
Fix jpeg generation for sinistro images 

### DIFF
--- a/fits2image/scaling.py
+++ b/fits2image/scaling.py
@@ -193,7 +193,15 @@ def get_reduced_dimensionality_data(path_to_frame):
     with path_to_frame.open('rb') as p:
         with fits.open(p) as hdul:
             for hdu in hdul:
-                if len(np.shape(hdu)) == 2:
+                '''
+                For most images the shape of first HDU data is () and the first HDU data is the 
+                dimensions of the CCD.
+                For sinistro, the first HDU data has shape (0,0) and subsequent HDUs are 1/4 of
+                the chip dimensions.
+                Therefore, just checking for a shape with 2 elements is not sufficient to identify data.
+                We also need to check for non-zero shape elements.
+                '''
+                if len(np.shape(hdu)) == 2 and np.shape(hdu)[0] > 0:
                     return hdu.data, hdu.header
         raise Exception('No fits data found')
 


### PR DESCRIPTION
This broke when we moved from fitsio to astropy.
My fix is not elegant but seems to work. 
For reference the HDU data shapes for an NRES sinsitro image (working) are:
>>> np.shape(hdu2[0])
()
>>> np.shape(hdu2[1])
(4108, 4160)

while for an imaging sinistro (broken):

>>> np.shape(hdul[0])
(0, 0)
>>> np.shape(hdul[1])
(2058, 2080)
>>> np.shape(hdul[2])
(2058, 2080)
>>> np.shape(hdul[3])
(2058, 2080)

This will make sense when you look at the fix.

https://www.pivotaltracker.com/story/show/178235941