### PR TITLE
ANTIALIAS has been deprecated; using LANCZOS

### DIFF
--- a/fits2image/conversions.py
+++ b/fits2image/conversions.py
@@ -52,7 +52,7 @@ def fits_to_jpg(path_to_fits, path_to_jpg, width=200, height=200, progressive=Fa
         scaled_images = [stack_images(scaled_images)]
 
     for idx, im in enumerate(scaled_images):
-        im.thumbnail((width, height), Image.ANTIALIAS)
+        im.thumbnail((width, height), Image.LANCZOS)
         if label_text:
             try:
                 _add_label(im, label_text, label_font)
@@ -95,7 +95,7 @@ def fits_to_zoom_slice_jpg(path_to_fits, path_to_jpg, row=0, col=0, side=200, zl
     x = int(col * step)
     y = int(row * step)
     im = im.crop((x, y, x+step, y+step))
-    im.thumbnail((width, height), Image.ANTIALIAS)
+    im.thumbnail((width, height), Image.LANCZOS)
     if label_text:
         try:
             _add_label(im, label_text, label_font)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ DESCRIPTION = """Common libraries for the conversion and scaling of fits images"
 
 setup(
     name="fits2image",
-    version="0.4.6",
+    version="0.4.7",
     description=DESCRIPTION,
     long_description=DESCRIPTION,
     author='Jon Nation',


### PR DESCRIPTION
In Pillow 10.0.0 `ANTIALIAS` has been removed. The recommendation is that `LANCZOS` [be used instead](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants),