### PR TITLE
resize images to min before stacking

### DIFF
--- a/fits2image/scaling.py
+++ b/fits2image/scaling.py
@@ -31,6 +31,16 @@ def get_scaled_image(path_to_fits, zmin=None, zmax=None, contrast=0.1, gamma_adj
 
 
 def stack_images(images_to_stack):
+    sizes = [img.size for img in images_to_stack]
+
+    widths = [size[0] for size in sizes]
+    heights = [size[1] for size in sizes]
+
+    min_width = min(widths)
+    min_height = min(heights)
+
+    images_to_stack = [img.resize((min_width, min_height), Image.LANCZOS) for img in images_to_stack]
+
     rgb_cube = np.dstack(images_to_stack).astype(np.uint8)
     return Image.fromarray(rgb_cube)
 

--- a/fits2image/scaling.py
+++ b/fits2image/scaling.py
@@ -55,8 +55,8 @@ def stack_images(images_to_stack):
             right = left + target_width
             bottom = top + target_height
 
-            img = img.crop((left, top, right, bottom))
-            cropped_images.append(img)
+            cropped_img = img.crop((left, top, right, bottom))
+            cropped_images.append(cropped_img)
 
         rgb_cube = np.dstack(cropped_images).astype(np.uint8)
 


### PR DESCRIPTION
Error Message 
```
all the input array dimensions except for the concatenation axis must match exactly, but along dimension 0, the array at index 0 has size 2042 and the array at index 1 has size 2400
```

When `fits2img` would encounter differently sized images to stack the `dstack` would raise an uncaught exception. Now we catch that and have a fallback where we crop all the images to a minimum size. It's in the except block so we don't need to crop for every image just the ones that fail.

Handles an edge case as most of the time you would be stacking images from the same camera, but just so that datalab can be robust and users can do just about anything this will allow stacking of any image